### PR TITLE
Initialise sbt in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,20 @@ ENV SONAR_SCANNER_PACKAGE=sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip
 
 USER root
 
-SHELL ["/bin/bash", "-o", "pipefail", "-x", "-c"]
+SHELL ["/bin/bash", "-eo", "pipefail", "-x", "-c"]
 
 # Install Scala
 RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release && \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /opt/ && \
   ln -s /opt/scala-* /opt/scala && \
   /opt/scala/bin/scala -version
+
+# Initialise SBT to download scala and the compiler-bridge
+RUN export TEMP="$(mktemp -d)" && \
+    cd "${TEMP}" && \
+    echo "class Question { def answer = 42 }" > Question.scala && \
+    sbt "set scalaVersion := \"${SCALA_VERSION}\"" compile && \
+    rm -r "${TEMP}"
 
 # Install the AWS CLI
 RUN curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip && \


### PR DESCRIPTION
On the first execution, sbt downloads some scala jars and on first
compile it also compiles the compiler-bridge:

```
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.9/scala-library-2.12.9.jar ...
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.9/scala-compiler-2.12.9.jar ...                                                                                                
[info] downloading https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.9/scala-reflect-2.12.9.jar ...                                                                                                  
[info] downloading https://repo1.maven.org/maven2/org/fusesource/jansi/jansi/1.12/jansi-1.12.jar ...
[info]  [SUCCESSFUL ] org.scala-lang#scala-reflect;2.12.9!scala-reflect.jar (454ms)                                                                                                                                 
[info]  [SUCCESSFUL ] org.fusesource.jansi#jansi;1.12!jansi.jar (446ms)                                   
[info]  [SUCCESSFUL ] org.scala-lang#scala-library;2.12.9!scala-library.jar (1096ms)                      
[info]  [SUCCESSFUL ] org.scala-lang#scala-compiler;2.12.9!scala-compiler.jar (1518ms)
[info] Done updating.                                                                                     
[info] Compiling 1 Scala source to /tmp/tmp.hrfM92SWVI/target/scala-2.12/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.9. Compiling...                                                                                                                                    
[info]   Compilation completed in 8.037s.
```

This adds the necessary steps to already do this in the docker image, so CI doesn't have to do
it every time.