### PR TITLE
Add echo with tag of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ USER circleci
 # Define working directory
 WORKDIR /home/circleci
 
-RUN echo -e "Tag for this image:\n$(java -version 2>&1 | head -n 1 | grep -o '[[:digit:]._]*')-${SCALA_VERSION}-${KUBECTL_VERSION}-1"
+RUN echo -e "Tag for this image:\n8u222-${SCALA_VERSION}-${KUBECTL_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,3 +60,5 @@ USER circleci
 
 # Define working directory
 WORKDIR /home/circleci
+
+RUN echo -e "Tag for this image:\n$(java -version 2>&1 | head -n 1 | grep -o '[[:digit:]._]*')-${SCALA_VERSION}-${KUBECTL_VERSION}-1"


### PR DESCRIPTION
I think we should change the tag to:

- include the kubectl version
- include another version for the image that can be incremented if neither scala nor kubectl version changes

At the end of the build I added a step that echos the correct tag for the built image which looks like this:

`1.8.0_222-2.12.9-v1.14.5-1`